### PR TITLE
Base-64 encode answer code.

### DIFF
--- a/app/routes/answer.py
+++ b/app/routes/answer.py
@@ -1,4 +1,5 @@
 from flask import request, g, abort, jsonify
+from base64 import b64decode
 
 from app.controllers import answer
 from app.server import server
@@ -12,7 +13,7 @@ def publish_answer():
     post_id = request.form['post_id']
 
     # Important parts
-    code = request.form['code']
+    code = b64decode(request.form['code'])
     lang_id = request.form.get('lang_id', None)
     lang_name = request.form.get('lang_name', None)
 

--- a/static/js/controllers/AceViewController.js
+++ b/static/js/controllers/AceViewController.js
@@ -20,6 +20,7 @@ export default class AceViewController extends ViewController {
         this._editor.container.controller = this;
 
         this._editor.session.setNewLineMode('unix');
+        this._editor.session.getDocument().setNewLineMode('unix');
 
         /**
          * @type {AceTheme}

--- a/static/js/ui/write/answer.js
+++ b/static/js/ui/write/answer.js
@@ -50,7 +50,7 @@ if (formController = ViewController.of(ANSWER_FORM)) {
 
         formWillSubmit(controller) {
             super.formWillSubmit(controller);
-            controller.setFieldWithName(editor.value, ANSWER_CODE_NAME);
+            controller.setFieldWithName(btoa(editor.value), ANSWER_CODE_NAME);
         }
     }
 }


### PR DESCRIPTION
This should result incorrect byte-counting for code that wouldn't be as newlines are encoded as 2-bytes since HTTP form encoding converts LF to CRLF

Fixes #122

Signed-off-by: Vihan <contact@vihan.org>