### PR TITLE
Fix API key for deploy

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -7,10 +7,6 @@ import app.tasks.update as update
 from shutil import which
 import bugsnag
 from bugsnag.flask import handle_exceptions
-import os
-
-import bugsnag
-from bugsnag.flask import handle_exceptions
 
 import config
 


### PR DESCRIPTION
Should have been part of the last PR but wasn't. This just changes the names of the env vars so they match up with what's in travis (previously it was what i had locally).

Signed-off-by: Vihan <contact@vihan.org>