### PR TITLE
Fix LoadMoreViewController called with deep child.

### DIFF
--- a/js/controllers/CommentListViewController.js
+++ b/js/controllers/CommentListViewController.js
@@ -171,7 +171,7 @@ export default class CommentListViewController extends ViewController {
                 this
             );
 
-            const loadMoreButton = commentList.querySelector('.comment-item__load-more');
+            const loadMoreButton = immediateChildWithClass(this._node, 'comment-item__load-more');
             if (loadMoreButton) {
                 new LoadMoreCommentsViewController(
                     loadMoreButton,

--- a/js/helpers/ErrorManager.js
+++ b/js/helpers/ErrorManager.js
@@ -44,6 +44,8 @@ export class AnyError {
         return this.id;
     }
 
+    get name() { return this.id; }
+
     toString() {
         return this.id + ": " + this.message;
     }
@@ -148,7 +150,7 @@ export class ErrorManager {
      */
     unhandled(error) {
         report_manager('error', error);
-        new AnyError(error.message, 'Unhandled Error').report(error, error.stack);
+        new AnyError(error.message, `Unhandled Error (${error.name})`).report(error, error.stack);
     }
 
     /**
@@ -202,3 +204,4 @@ export class ErrorManager {
 
 ErrorManager.shared = new ErrorManager();
 export default ErrorManager.shared;
+export const HandleUnhandledPromise = (reason) => ErrorManager.shared.unhandled(reason);

--- a/js/main.js
+++ b/js/main.js
@@ -22,7 +22,7 @@ import Analytics, { TimingType } from "~/models/Analytics";
 
 // Manage unhandled errors through manager
 window.addEventListener("unhandledrejection", (error) => {
-    ErrorManager.unhandled(error);
+    ErrorManager.unhandled(error.reason);
 });
 
 // This is a bunch of code which ensures that the UI code is called


### PR DESCRIPTION
Moved to `immediateChildWithClass` as the querySelector could return a
deep child meaning multiple controllers would incorrectly own the same
class.

Fixes #167

Signed-off-by: Vihan <contact@vihan.org>