### PR TITLE
Fixed typo in word 'FAWs'

### DIFF
--- a/templates/help/faq.html
+++ b/templates/help/faq.html
@@ -11,7 +11,7 @@
 {% block title %}FAQs{% endblock %}
 {% block content -%}
     <div class="list-header">
-        <h1>FAWs.</h1>
+        <h1>FAQs.</h1>
     </div>
     <div class="list-header list-header--style-caption">
         <h2 class="header--style-caption">Sorry, no FAQ yet =( feel free to make a PR.</h2>


### PR DESCRIPTION
Fixes a minor typo that showed up on the Help Center > FAQ page.